### PR TITLE
Adjustments to facilitate localhost captures

### DIFF
--- a/FauCap/Converter.cs
+++ b/FauCap/Converter.cs
@@ -49,8 +49,9 @@ namespace FauCap
 
         void OnPacketArrival(object sender, CaptureEventArgs e)
         {
-            if (e.Packet.LinkLayerType == PacketDotNet.LinkLayers.Ethernet)
+            if (e.Packet.LinkLayerType == PacketDotNet.LinkLayers.Ethernet || e.Packet.LinkLayerType == PacketDotNet.LinkLayers.Null)
             {
+                
                 var packet = PacketDotNet.Packet.ParsePacket(e.Packet.LinkLayerType, e.Packet.Data);
 
                 var udpPacket = (PacketDotNet.UdpPacket)packet.Extract<PacketDotNet.UdpPacket>();
@@ -61,7 +62,6 @@ namespace FauCap
                 byte[] data = udpPacket.PayloadData;
 
                 DateTime time = e.Packet.Timeval.Date;
-
                 if (IsHandshakePacket(data))
                 {
                     switch (Handshake.ReadName(data))

--- a/FauCap/Converter.cs
+++ b/FauCap/Converter.cs
@@ -127,7 +127,8 @@ namespace FauCap
                 }
                 else if (data != null && CurrentStatus == Status.Hugged && Sessions.Last().SocketID == MemoryMarshal.Read<uint>(data))
                 {
-                    bool fromServer = ipPacket.DestinationAddress.Address == Sessions.Last().LocalIp.Address;
+                    
+                    bool fromServer = udpPacket.SourcePort == Sessions.Last().GameServerPort;
                     Sessions.Last().Datagrams.Add(new Datagram(Idx++, time, fromServer, data));
                 }
 

--- a/FauCap/FauCap.csproj
+++ b/FauCap/FauCap.csproj
@@ -9,9 +9,9 @@
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <Product>FauCap</Product>
     <Version>1.12.0.0</Version>
-    <AssemblyVersion>1.13.0.0</AssemblyVersion>
+    <AssemblyVersion>1.14.0.0</AssemblyVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>1.13.0.0</PackageVersion>
+    <PackageVersion>1.14.0.0</PackageVersion>
   </PropertyGroup>
 
   

--- a/FauCap/PacketUtil.cs
+++ b/FauCap/PacketUtil.cs
@@ -61,7 +61,7 @@ namespace FauCap
             }
             public static ushort ReadGameServerPort(Span<byte> data)
             {
-                return MemoryMarshal.Read<ushort>(data.Slice(10, 2));
+                return ReadUInt16BigEndian(data.Slice(10, 2));
             }
         }
     }

--- a/FauCapParser/FauCapParser.csproj
+++ b/FauCapParser/FauCapParser.csproj
@@ -6,9 +6,9 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>TheMeldingWars</Company>
-    <AssemblyVersion>1.13.0.0</AssemblyVersion>
+    <AssemblyVersion>1.14.0.0</AssemblyVersion>
     <Version>1.12.0.0</Version>
-    <PackageVersion>1.13.0.0</PackageVersion>
+    <PackageVersion>1.14.0.0</PackageVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Should fix issues where FauCap doesn't identify any sessions if using loopback traffic capture.
Seems to still work with (after converting to pcap) [2016-11-15 - Gameplay.pcapng.gz](https://github.com/themeldingwars/Documentation/blob/master/Captures/2016-11-15%20-%20Gameplay.pcapng.gz) and [2015-05-02 - 1869 - Gameplay.pcapng.gz](https://github.com/themeldingwars/Documentation/blob/master/Captures/2015-05-02%20-%201869%20-%20Gameplay.pcapng.gz), so seems good to me.

Do we use game server port anywhere else?